### PR TITLE
Fix frontend API response handling

### DIFF
--- a/graphrag-gemini-studio/src/api/types.ts
+++ b/graphrag-gemini-studio/src/api/types.ts
@@ -1,7 +1,14 @@
 export interface ApiResponse<T> {
-  code: number;
+  /** 接口调用是否成功 */
+  success: boolean;
+  /** 返回代码，如 SUCCESS/ERROR */
+  code: string;
+  /** 提示信息 */
   message: string;
+  /** 实际数据 */
   data: T;
+  /** 服务器返回时间 */
+  timestamp?: string;
 }
 
 export type RetrievalMode = 'vector' | 'graph' | 'hybrid';
@@ -23,9 +30,20 @@ export interface Segment {
 }
 
 export interface GraphRagResponse {
+  question: string;
   answer: string;
-  segments: Segment[];
+  /** 相关文档列表 */
+  relevantDocuments: Record<string, any>[];
+  /** 相关实体列表 */
+  relevantEntities: Record<string, any>[];
+  /** 实体关系路径 */
+  relationshipPaths?: Record<string, any>[];
+  /** 模型信心度 */
+  confidence?: number;
+  /** 处理耗时 */
   processingTimeMs: number;
+  /** 兼容旧版字段 */
+  segments?: Segment[];
 }
 
 export interface QueryAnalysis {

--- a/graphrag-gemini-studio/src/components/FileUploader.tsx
+++ b/graphrag-gemini-studio/src/components/FileUploader.tsx
@@ -12,7 +12,7 @@ const FileUploader: React.FC = () => {
   const uploadMutation = useMutation({
     mutationFn: (file: File) => graphRagApi.uploadDocument(file),
     onSuccess: (response) => {
-      if (response.code === 0) {
+      if (response.success) {
         message.success(response.data || '文件上传成功!');
       } else {
         message.error(response.message);

--- a/graphrag-gemini-studio/src/components/ResultDisplay.tsx
+++ b/graphrag-gemini-studio/src/components/ResultDisplay.tsx
@@ -24,11 +24,11 @@ const ResultDisplay: React.FC<Props> = ({ data }) => {
 
       <Collapse accordion>
         <Panel
-          header={`推理依据 (${data.segments.length}个片段)`}
+          header={`推理依据 (${data.segments?.length ?? 0}个片段)`}
           key="1"
         >
           <div className="space-y-md max-h-96 overflow-y-auto pr-sm">
-            {data.segments.map((seg, index) => (
+            {data.segments?.map((seg, index) => (
               <Card key={index} size="small">
                 <div className="flex justify-between items-start">
                   <FileTextOutlined className="mr-sm mt-1" />

--- a/graphrag-gemini-studio/src/pages/Dashboard/index.tsx
+++ b/graphrag-gemini-studio/src/pages/Dashboard/index.tsx
@@ -13,7 +13,7 @@ const DashboardPage: React.FC = () => {
   const queryMutation = useMutation({
     mutationFn: (request: GraphRagRequest) => graphRagApi.query(request),
     onSuccess: (response) => {
-      if (response.code === 0) {
+      if (response.success) {
         setResult(response.data);
       } else {
         message.error(response.message);

--- a/graphrag-gemini-studio/src/pages/GraphExplorer/index.tsx
+++ b/graphrag-gemini-studio/src/pages/GraphExplorer/index.tsx
@@ -12,12 +12,13 @@ const GraphExplorerPage: React.FC = () => {
 
   const { data, isLoading, isError, error } = useQuery<RelatedEntityInfo[], Error>({
     queryKey: ['relatedEntities', searchTrigger],
-    queryFn: () => graphRagApi.getRelatedEntities(searchTrigger).then(response => {
-      if (response.code === 0) {
-        return response.data;
-      }
-      throw new Error(response.message);
-    }),
+    queryFn: () =>
+      graphRagApi.getRelatedEntities(searchTrigger).then((response) => {
+        if (response.success) {
+          return response.data;
+        }
+        throw new Error(response.message);
+      }),
     enabled: !!searchTrigger,
   });
   // 使用 useEffect 來處理錯誤訊息

--- a/graphrag-gemini-studio/src/pages/Statistics/index.tsx
+++ b/graphrag-gemini-studio/src/pages/Statistics/index.tsx
@@ -13,7 +13,7 @@ const StatisticsPage: React.FC = () => {
     queryKey: ['graphStats'],
     queryFn: () => graphRagApi.getStats(),
     select: (response) => {
-      if (response.code === 0) {
+      if (response.success) {
         return response.data;
       }
       throw new Error(response.message);


### PR DESCRIPTION
## Summary
- align ApiResponse and GraphRagResponse types with backend
- update pages/components to check `success` field
- handle absence of segments

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6853a46eace08327a72169533f810097