### PR TITLE
Add tools page and markdown rendering

### DIFF
--- a/graph-rag-solution/graph-rag-api/pom.xml
+++ b/graph-rag-solution/graph-rag-api/pom.xml
@@ -44,6 +44,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <!-- WebFlux for reactive streaming -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
 
         <!-- Spring Boot Actuator (監控) -->
         <dependency>

--- a/graphrag-gemini-studio/package.json
+++ b/graphrag-gemini-studio/package.json
@@ -24,7 +24,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "react-markdown": "^9.0.3",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@types/cytoscape": "^3.21.0",

--- a/graphrag-gemini-studio/src/App.tsx
+++ b/graphrag-gemini-studio/src/App.tsx
@@ -3,6 +3,7 @@ import PageLayout from './layouts/PageLayout';
 import DashboardPage from './pages/Dashboard';
 import GraphExplorerPage from './pages/GraphExplorer';
 import StatisticsPage from './pages/Statistics';
+import ToolsPage from './pages/Tools';
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="dashboard" element={<DashboardPage />} />
         <Route path="explorer" element={<GraphExplorerPage />} />
         <Route path="statistics" element={<StatisticsPage />} />
+        <Route path="tools" element={<ToolsPage />} />
       </Route>
     </Routes>
   );

--- a/graphrag-gemini-studio/src/api/graphRagApi.ts
+++ b/graphrag-gemini-studio/src/api/graphRagApi.ts
@@ -14,6 +14,26 @@ export const graphRagApi = {
   ): Promise<ApiResponse<GraphRagResponse>> =>
     axiosClient.post('/query', request),
 
+  queryStream: (
+    request: GraphRagRequest,
+    onMessage: (data: ApiResponse<GraphRagResponse>) => void,
+    onError?: (err: any) => void
+  ): EventSource => {
+    const params = new URLSearchParams({
+      question: request.question,
+      retrievalMode: request.retrievalMode || 'hybrid',
+    });
+    const es = new EventSource(`/query/stream?${params.toString()}`);
+    es.onmessage = (ev) => {
+      onMessage(JSON.parse(ev.data));
+    };
+    es.onerror = (err) => {
+      onError?.(err);
+      es.close();
+    };
+    return es;
+  },
+
   submitAsyncQuery: (
     request: GraphRagRequest
   ): Promise<ApiResponse<string>> =>

--- a/graphrag-gemini-studio/src/components/ResultDisplay.tsx
+++ b/graphrag-gemini-studio/src/components/ResultDisplay.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Card, Typography, Descriptions, Tag, Collapse } from 'antd';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { GraphRagResponse } from '@/api/types';
 import { CheckCircleOutlined, FileTextOutlined } from '@ant-design/icons';
 
-const { Paragraph, Text } = Typography;
+const { Text } = Typography;
 const { Panel } = Collapse;
 
 interface Props {
@@ -19,7 +21,9 @@ const ResultDisplay: React.FC<Props> = ({ data }) => {
             {data.processingTimeMs} ms
           </Descriptions.Item>
         </Descriptions>
-        <Paragraph className="text-base">{data.answer}</Paragraph>
+        <ReactMarkdown remarkPlugins={[remarkGfm as any]} className="whitespace-pre-wrap">
+          {data.answer}
+        </ReactMarkdown>
       </Card>
 
       <Collapse accordion>
@@ -32,7 +36,14 @@ const ResultDisplay: React.FC<Props> = ({ data }) => {
               <Card key={index} size="small">
                 <div className="flex justify-between items-start">
                   <FileTextOutlined className="mr-sm mt-1" />
-                  <Paragraph className="flex-1 !mb-0">{seg.content}</Paragraph>
+                  <div className="flex-1">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm as any]}
+                      className="whitespace-pre-wrap !mb-0"
+                    >
+                      {seg.content}
+                    </ReactMarkdown>
+                  </div>
                   <Tag
                     icon={<CheckCircleOutlined />}
                     color="success"

--- a/graphrag-gemini-studio/src/layouts/PageLayout.tsx
+++ b/graphrag-gemini-studio/src/layouts/PageLayout.tsx
@@ -5,6 +5,7 @@ import {
   DashboardOutlined,
   ApartmentOutlined,
   LineChartOutlined,
+  ToolOutlined,
   UserOutlined,
 } from '@ant-design/icons';
 import { useSelector, useDispatch } from 'react-redux';
@@ -29,6 +30,11 @@ const navigationItems = [
     key: '/statistics',
     icon: <LineChartOutlined />,
     label: '系统状态',
+  },
+  {
+    key: '/tools',
+    icon: <ToolOutlined />,
+    label: '工具',
   },
 ];
 

--- a/graphrag-gemini-studio/src/pages/Tools/index.tsx
+++ b/graphrag-gemini-studio/src/pages/Tools/index.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+import { Card, Input, Button, App, Space, Typography } from 'antd';
+import ResultDisplay from '@/components/ResultDisplay';
+import { graphRagApi } from '@/api/graphRagApi';
+import { GraphRagResponse, QueryAnalysis } from '@/api/types';
+
+const { Paragraph } = Typography;
+
+const ToolsPage: React.FC = () => {
+  const { message } = App.useApp();
+
+  const [analysisInput, setAnalysisInput] = useState('');
+  const [analysis, setAnalysis] = useState<QueryAnalysis | null>(null);
+  const [analysisLoading, setAnalysisLoading] = useState(false);
+
+  const [asyncQuestion, setAsyncQuestion] = useState('');
+  const [taskId, setTaskId] = useState<string | null>(null);
+  const [asyncResult, setAsyncResult] = useState<GraphRagResponse | null>(null);
+  const [asyncStatus, setAsyncStatus] = useState('');
+  const [asyncLoading, setAsyncLoading] = useState(false);
+
+  const handleAnalyze = () => {
+    if (!analysisInput.trim()) {
+      message.warning('请输入查询');
+      return;
+    }
+    setAnalysis(null);
+    setAnalysisLoading(true);
+    graphRagApi
+      .analyzeQuery(analysisInput)
+      .then((res) => {
+        if (res.success) {
+          setAnalysis(res.data);
+        } else {
+          message.error(res.message);
+        }
+      })
+      .catch((err) => message.error(err.message))
+      .finally(() => setAnalysisLoading(false));
+  };
+
+  const handleSubmitAsync = () => {
+    if (!asyncQuestion.trim()) {
+      message.warning('请输入问题');
+      return;
+    }
+    setAsyncLoading(true);
+    setAsyncResult(null);
+    setAsyncStatus('');
+    graphRagApi
+      .submitAsyncQuery({ question: asyncQuestion })
+      .then((res) => {
+        if (res.success) {
+          setTaskId(res.data);
+          message.success('任务已提交');
+        } else {
+          message.error(res.message);
+        }
+      })
+      .catch((err) => message.error(err.message))
+      .finally(() => setAsyncLoading(false));
+  };
+
+  const handleGetResult = () => {
+    if (!taskId) return;
+    setAsyncLoading(true);
+    graphRagApi
+      .getAsyncResult(taskId)
+      .then((res) => {
+        if (!res.success) {
+          message.error(res.message);
+          return;
+        }
+        if (res.data === 'running' || res.data === 'task not found') {
+          setAsyncStatus(res.data);
+        } else {
+          setAsyncResult(res.data);
+          setAsyncStatus('completed');
+        }
+      })
+      .catch((err) => message.error(err.message))
+      .finally(() => setAsyncLoading(false));
+  };
+
+  const handleHealth = () => {
+    graphRagApi
+      .checkHealth()
+      .then((res) => {
+        if (res.success) {
+          message.success(res.data);
+        } else {
+          message.error(res.message);
+        }
+      })
+      .catch((err) => message.error(err.message));
+  };
+
+  const handleClear = () => {
+    graphRagApi
+      .clearGraph()
+      .then((res) => {
+        if (res.success) {
+          message.success(res.data);
+        } else {
+          message.error(res.message);
+        }
+      })
+      .catch((err) => message.error(err.message));
+  };
+
+  return (
+    <Space direction="vertical" size="large" className="w-full">
+      <Card title="查询分析">
+        <Input.Search
+          placeholder="输入问题以分析其类型"
+          enterButton="分析"
+          value={analysisInput}
+          onChange={(e) => setAnalysisInput(e.target.value)}
+          onSearch={handleAnalyze}
+          loading={analysisLoading}
+        />
+        {analysis && (
+          <Paragraph className="mt-md">
+            {JSON.stringify(analysis, null, 2)}
+          </Paragraph>
+        )}
+      </Card>
+
+      <Card title="异步问答">
+        <Space direction="vertical" className="w-full">
+          <Input.Search
+            placeholder="输入问题提交异步任务"
+            enterButton="提交"
+            value={asyncQuestion}
+            onChange={(e) => setAsyncQuestion(e.target.value)}
+            onSearch={handleSubmitAsync}
+            loading={asyncLoading}
+          />
+          {taskId && (
+            <Space>
+              <span>任务ID: {taskId}</span>
+              <Button onClick={handleGetResult} loading={asyncLoading}>
+                获取结果
+              </Button>
+              {asyncStatus && <span>状态: {asyncStatus}</span>}
+            </Space>
+          )}
+          {asyncResult && <ResultDisplay data={asyncResult} />}
+        </Space>
+      </Card>
+
+      <Card title="系统运维">
+        <Space>
+          <Button onClick={handleHealth}>健康检查</Button>
+          <Button danger onClick={handleClear}>
+            清空知识图谱
+          </Button>
+        </Space>
+      </Card>
+    </Space>
+  );
+};
+
+export default ToolsPage;


### PR DESCRIPTION
## Summary
- render Markdown using `react-markdown`
- add new Tools page covering remaining APIs
- include Tools page in routes and sidebar

## Testing
- `npm --version`
- `HUSKY=0 npm install --silent`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ab6455c483278db37ec0ddcff774